### PR TITLE
change from stderr to stdout in insertMany success

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -11,7 +11,7 @@ mongoose.connect(dbURI);
 
 Employee.insertMany(data)
   .then(() => {
-    process.stderr.write('Employees created...\n');
+    process.stdout.write('Employees created...\n');
     process.exit(0);
   })
   .catch(() => {


### PR DESCRIPTION
Shouldn't it be `process.stdout.write('Employees created...\n')` instead of `process.stderr.write(...)` in case of success of insertion ?

You project is nice to read btw. Beautiful code 👍  Learned a lot.